### PR TITLE
Bump R-CMD-check-action to v2

### DIFF
--- a/.github/workflows/r-lib-check.yaml
+++ b/.github/workflows/r-lib-check.yaml
@@ -1,5 +1,5 @@
 ---
-name: R-CMD-check (r-lib)
+name: R-CMD-check
 'on':
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/r-lib-check.yaml
+++ b/.github/workflows/r-lib-check.yaml
@@ -19,4 +19,4 @@ jobs:
           tlmgr install \
           cite \
           grfext
-      - uses: uclahs-cds/tool-R-CMD-check-action@main
+      - uses: uclahs-cds/tool-R-CMD-check-action@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: NanoStringNorm
 Type: Package
 Title: Normalize NanoString miRNA and mRNA Data
 Version: 3.0.0
-Date: 2025-01-17
+Date: 2025-06-17
 Authors@R: c(
 	person(c("Daryl", "M."), "Waggott", role = "aut"),
 	person("Paul", "Boutros", email = "PBoutros@mednet.ucla.edu", role = "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# NanoStringNorm 3.0.0 (2025-01-17)
+# NanoStringNorm 3.0.0 (2025-06-17)
 
 ## Removed
 * Removed Excel `.xls` support due to broken CRAN dependency
@@ -9,6 +9,7 @@
 ## Changed
 * Update changelog to Markdown format
 * Replaced RUnit framework with testthat
+* Update `R CMD check` CI/CD action
 
 
 # NanoStringNorm 2.0.0 (2023-03-21)


### PR DESCRIPTION
This PR updates the `R CMD check` action to its newest `v2` release.
